### PR TITLE
Setting label io.balena.features.balena-api 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# IDE
+.vscode
 
 deps/.DS_Store
 .DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,5 @@ services:
       #TC_TRUST:            # uses TTN certificates by default
       TC_KEY:
       #EUI_ADDRESS:         # required if you use a Pi Zero W or Pi Zero 2 W
+    labels:
+      io.balena.features.balena-api: '1'


### PR DESCRIPTION
This ensures the BALENA_API_KEY is injected into the container and `start.sh` can successfully set the EUI tag.

Without the label, _BALENA_API_KEY_ is not available in the container and the script logs a parse error originating from this line where _BALENA_API_KEY_ will be empty.

```
ID=$(curl -sX GET "https://api.balena-cloud.com/v5/device?\$filter=uuid%20eq%20'$BALENA_DEVICE_UUID'" \
-H "Content-Type: application/json" \
-H "Authorization: Bearer $BALENA_API_KEY" | \
jq ".d | .[0] | .id")
```