### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## This project is deprecated! You can see the balena basicstation updated here
 
-[https://github.com/xoseperez/basicstation](https://github.com/xoseperez/basicstation)
+[https://github.com/xoseperez/basicstation-docker](https://github.com/xoseperez/basicstation-docker)
 
 ---
 


### PR DESCRIPTION
The original link points to the basic station source code. This should rather point to the Docker setup to run in Balena.